### PR TITLE
Hotfix - The mobile design breaks when you display two or more questions

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,10 +63,10 @@
       <h1 class="accordition-title">FAQ</h1>
       <div class="accordition-container">
         <input
-          class="accordition-container__checkbox accordition-container__checkbox--checked"
-          type="checkbox"
+          class="accordition-container__radio accordition-container__radio--checked"
+          type="radio"
           id="title1"
-          name="checkbox_list"
+          name="radio_list"
         />
 
         <label
@@ -86,10 +86,11 @@
       <span class="accordition__divider"></span>
       <div class="accordition-container">
         <input
-          class="accordition-container__checkbox accordition-container__checkbox--checked"
-          type="checkbox"
+          class="accordition-container__radio accordition-container__radio--checked"
+          type="radio"
           id="title2"
-          name="checkbox_list"
+          name="radio_list"
+          checked
         />
         <label
           class="accordition-container__label accordition-container__label--hover"
@@ -108,10 +109,10 @@
       <span class="accordition__divider"></span>
       <div class="accordition-container">
         <input
-          class="accordition-container__checkbox accordition-container__checkbox--checked"
-          type="checkbox"
+          class="accordition-container__radio accordition-container__radio--checked"
+          type="radio"
           id="title3"
-          name="checkbox_list"
+          name="radio_list"
         />
         <label
           class="accordition-container__label accordition-container__label--hover"
@@ -130,10 +131,10 @@
       <span class="accordition__divider"></span>
       <div class="accordition-container">
         <input
-          class="accordition-container__checkbox accordition-container__checkbox--checked"
-          type="checkbox"
+          class="accordition-container__radio accordition-container__radio--checked"
+          type="radio"
           id="title4"
-          name="checkbox_list"
+          name="radio_list"
         />
         <label
           class="accordition-container__label accordition-container__label--hover"
@@ -152,10 +153,10 @@
       <span class="accordition__divider"></span>
       <div class="accordition-container">
         <input
-          class="accordition-container__checkbox accordition-container__checkbox--checked"
-          type="checkbox"
+          class="accordition-container__radio accordition-container__radio--checked"
+          type="radio"
           id="title5"
-          name="checkbox_list"
+          name="radio_list"
         />
 
         <label

--- a/style.css
+++ b/style.css
@@ -70,7 +70,7 @@ body{
     
     width:320px;
     height:auto;
-    min-height: 490px;
+    min-height: 590px;
     margin:0 auto;
     display:flex;
     align-self: center;
@@ -130,13 +130,13 @@ body{
 
 }
 
-.accordition-container__checkbox {
+.accordition-container__radio {
     display: none;
 
 }
 
 .accordition-title{
-    margin-top: 240px;
+    margin-top: 140px;
     text-align: center;
 
 }
@@ -217,7 +217,7 @@ body{
 
 }
 
-.accordition-container__checkbox + 
+.accordition-container__radio + 
 .accordition-container__label + 
 .accordition-container__container {
     margin:0;
@@ -228,7 +228,7 @@ body{
 
 }
 
-.accordition-container__checkbox--checked:checked + 
+.accordition-container__radio--checked:checked + 
 .accordition-container__label + 
 .accordition-container__container {
     display: block;
@@ -283,18 +283,18 @@ body{
     
 }
 
-.accordition-container__checkbox:checked + .accordition-container__label>.accordition-container_image{
+.accordition-container__radio:checked + .accordition-container__label>.accordition-container_image{
     position: relative;
     animation: easing ease-in 390ms;
     animation-fill-mode: forwards;
 
 }
 
-.accordition-container__checkbox:checked + .accordition-container__label{
+.accordition-container__radio:checked + .accordition-container__label{
     color: var(--VeryDarkDesaturatedBlue);
     font-weight: var(--FontWeightLarge);
     animation: ease-in 2s;
-    transition: ease-in 5s;
+    transition: ease-in 1s;
 
 }
 


### PR DESCRIPTION
#3 The mobile design breaks when you display two or more questions 

Hello Carlos! The mobile design breaks when you display two or more questions, they fall out of the container. I suggest you let the container grow as long as it wants or only have one question displayed at a time.

Replaced input(from checkbox to radio) elements and set default min-width.